### PR TITLE
Add GameEvent Architecture

### DIFF
--- a/CatchTheButterflyProject/Assets/Scripts/Utilities/GameEvents.meta
+++ b/CatchTheButterflyProject/Assets/Scripts/Utilities/GameEvents.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d7ec56597b21c5649aac64cf1ee6dc59
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CatchTheButterflyProject/Assets/Scripts/Utilities/GameEvents/GameEvent.cs
+++ b/CatchTheButterflyProject/Assets/Scripts/Utilities/GameEvents/GameEvent.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Represents an event of interest to many other classes. The Raise() function
+/// is called when the event is triggered, signaling all listeners to respond
+/// to a particular game event.
+/// </summary>
+[CreateAssetMenu]
+public class GameEvent : ScriptableObject
+{
+    /// <summary>
+    /// List of listeners interested in this event. When the event is raised,
+    /// each listener's "OnEventRaised()" method will be called. Click any of
+    /// the list's entries to ping the GameObject the listener is attached to.
+    /// </summary>
+    [Tooltip("List of listeners interested in this event. When the event is " + 
+    "raised, each listener's 'OnEventRaised()' method will be called. Click " + 
+    "any of the list's entries to ping the GameObject the listener is " + 
+    "attached to.")]
+    [SerializeField]
+    private List<GameEventListener> listeners =
+        new List<GameEventListener>();
+        
+    /// <summary>
+    /// Calls the OnEventRaised method of all registered listeners in reverse
+    /// order. The reverse order allows listeners to be removed from the
+    /// listener list as a result of a raised event.
+    /// </summary>
+    public void Raise()
+    {
+        if (listeners.Count > 0)
+        {
+            for (int i = listeners.Count - 1; i >= 0; i--)
+            {
+                listeners[i].OnEventRaised();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Adds a listener to the list of listeners. Each listener in the list
+    /// will have its OnEventRaised method called when this GameEvent is raised.
+    /// </summary>
+    /// <param name="listener">The listener to add to this GameEvent's list of
+    /// listeners.</param>
+    public void RegisterListener(GameEventListener listener)
+    {
+        listeners.Add(listener);
+    }
+
+    /// <summary>
+    /// Removes a listener to the list of listeners, if the passed listener
+    /// exists in the list.
+    /// </summary>
+    /// <param name="listener">The listener to remove from this GameEvent's list
+    /// of listeners.</param>
+    public void UnregisterListener(GameEventListener listener)
+    {
+        if (listeners.Contains(listener))
+        {
+            listeners.Remove(listener);
+        }
+    }
+}

--- a/CatchTheButterflyProject/Assets/Scripts/Utilities/GameEvents/GameEvent.cs.meta
+++ b/CatchTheButterflyProject/Assets/Scripts/Utilities/GameEvents/GameEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3b4177d0d37a90840af0ede281d36689
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CatchTheButterflyProject/Assets/Scripts/Utilities/GameEvents/GameEventListener.cs
+++ b/CatchTheButterflyProject/Assets/Scripts/Utilities/GameEvents/GameEventListener.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+using UnityEngine.Events;
+
+/// <summary>
+/// Class to be attached to GameObjects, allowing them to respond to specific
+/// GameEvent raise calls. Unity Event Responses can be configured in the 
+/// inspector, but the scope of all references should be within a single 
+/// GameObject.
+/// </summary>
+[System.Serializable]
+public class GameEventListener : MonoBehaviour
+{
+    /// <summary>
+    /// GameEvent that this listener will listen to.
+    /// </summary>
+    [Tooltip("GameEvent that this listener will listen to.")]
+    public GameEvent Event;
+
+    /// <summary>
+    /// Responses to trigger when the event is raised.
+    /// </summary>
+    [Tooltip("Responses to trigger when the event is raised.")]
+    public UnityEvent Response;
+
+    #region MonoBehaviour Methods
+    private void OnEnable()
+    {
+        Event.RegisterListener(this);
+    }
+    private void OnDisable()
+    {
+        Event.UnregisterListener(this);
+    }
+    #endregion
+
+    /// <summary>
+    /// Responds the the assigned GameEvent's raise call by invoking a Unity
+    /// Event.
+    /// </summary>
+    public void OnEventRaised()
+    {
+        Response.Invoke();
+    }
+}

--- a/CatchTheButterflyProject/Assets/Scripts/Utilities/GameEvents/GameEventListener.cs.meta
+++ b/CatchTheButterflyProject/Assets/Scripts/Utilities/GameEvents/GameEventListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 080641a3d33d28549b855753c00d51b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
+ GameEvents streamlines the observer pattern through ScriptableObject-based events. It promotes decoupling of functionality and removes in-scene dependencies by moving event data from the scene level to the asset level
+ Architecture is based on Ryan Hipple's 2017 Unite talk: https://www.youtube.com/watch?v=raQ3iHhE_Kk